### PR TITLE
SCRUM-71 Handle 401 errors by logging out the user

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -4,6 +4,7 @@ import {
   registerUser,
   forgotPasswordRequest,
   resetPasswordRequest,
+createApiWithLogout,
 } from "../util/api";
 
 const AuthContext = createContext();
@@ -20,6 +21,8 @@ export const AuthProvider = ({ children }) => {
       setUser(JSON.parse(savedUser));
     }
   }, []);
+
+  
 
   const login = async (formData) => {
     try {
@@ -51,8 +54,10 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
     setToken(null);
     localStorage.removeItem("token");
-    localStorage.removeItem("user");
+    localStorage.removeItem("user")
   };
+
+  const fetchWith401Check = createApiWithLogout(logout);
 
   const forgotPassword = async (email) => {
     try {
@@ -85,6 +90,7 @@ export const AuthProvider = ({ children }) => {
         register,
         forgotPassword,
         resetPassword,
+        fetchWith401Check,
       }}
     >
       {children}

--- a/src/context/PostsContext.jsx
+++ b/src/context/PostsContext.jsx
@@ -5,7 +5,8 @@ import React, {
   useContext,
   useCallback,
 } from "react";
-import { getFilteredPosts, getPostById } from "../util/api";
+import { useAuth } from "../context/AuthContext";
+import { BASE_URL, normalizeItem } from "../util/api";
 
 const PostsContext = createContext();
 
@@ -16,6 +17,7 @@ function PostsProvider({ children }) {
   const [error, setError] = useState(null);
   const [activeCategories, setActiveCategories] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const { fetchWith401Check, token } = useAuth();
 
   async function fetchPosts() {
     try {
@@ -23,8 +25,25 @@ function PostsProvider({ children }) {
       setError(null);
 
       const category = activeCategories[0] || "";
-      const data = await getFilteredPosts(category, searchQuery);
-      setPosts(data);
+
+      const params = new URLSearchParams();
+      if (category) params.append("category", category);
+      if (searchQuery) params.append("search", searchQuery);
+
+      const res = await fetchWith401Check(
+        `${BASE_URL}/items?${params.toString()}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!res) return;
+
+      const data = await res.json();
+      setPosts(data.items || []);
     } catch (err) {
       setError(err.message || "Failed to fetch posts");
     } finally {
@@ -36,19 +55,31 @@ function PostsProvider({ children }) {
     fetchPosts();
   }, [activeCategories, searchQuery]);
 
-  const getPost = useCallback(async (id) => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      const post = await getPostById(id);
-      setCurrentPost(post);
-    } catch (err) {
-      setError(err.message || "Failed to fetch post");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const getPost = useCallback(
+    async (id) => {
+      try {
+        setIsLoading(true);
+        setError(null);
 
+        const res = await fetchWith401Check(`${BASE_URL}/items/${id}`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!res) return;
+        const data = await res.json();
+        setCurrentPost(normalizeItem(data.item));
+      } catch (err) {
+        setError(err.message || "Failed to fetch post");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [fetchWith401Check, token]
+  );
+  // TODO: Replace with real API call after PR is merged
   async function updatePost(id, updatedData) {
     try {
       setIsLoading(true);
@@ -67,7 +98,6 @@ function PostsProvider({ children }) {
       setIsLoading(false);
     }
   }
-
   async function deletePost(id) {
     try {
       setIsLoading(true);

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.VITE_API_URL;
+export const BASE_URL = import.meta.env.VITE_API_URL;
 
 export async function loginUser(credentials) {
   const res = await fetch(`${BASE_URL}/auth/login`, {
@@ -66,7 +66,7 @@ export async function updateUser(data, token) {
 }
 
 // Helper to normalize post item
-function normalizeItem(item) {
+export function normalizeItem(item) {
   const user = item.User || item.user || {};
   return {
     ...item,
@@ -169,3 +169,14 @@ export const deletePost = async (id) => {
 
   return normalizeItem(data.item);
 };
+
+export function createApiWithLogout(logout) {
+  return async function fetchWith401Check(url, options = {}) {
+    const res = await fetch(url, options);
+    if (res.status === 401) {
+      logout();
+      return;
+    }
+    return res;
+  };
+}


### PR DESCRIPTION
User is logged out after 401 response

A centralized function was created to automatically log out the user if a 401 Unauthorized response is received from the backend.

The fetchWith401Check() wrapper (via createApiWithLogout(logout)) is used to intercept fetch calls.
If a 401 status is returned, the user is logged out by clearing local storage and resetting the auth context state.